### PR TITLE
Make DBIx::Class::Schema::Loader an optional dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,8 @@ version          = 0.1506
 [Prereqs]
 Dancer                      = 0
 DBIx::Class                 = 0
+
+[Prereqs / RuntimeRecommends]
 DBIx::Class::Schema::Loader = 0.07002
 
 [MetaResources]

--- a/lib/Dancer/Plugin/DBIC.pm
+++ b/lib/Dancer/Plugin/DBIC.pm
@@ -6,8 +6,6 @@ use strict;
 use warnings;
 use Dancer::Plugin;
 use DBIx::Class;
-use DBIx::Class::Schema::Loader;
-DBIx::Class::Schema::Loader->naming('v7');
 
 my $schemas = {};
 
@@ -44,6 +42,11 @@ register schema => sub {
         }
         $schemas->{$name} = $schema_class->connect(@conn_info)
     } else {
+        eval { require DBIx::Class::Schema::Loader };
+        if ( my $err = $@ ) {
+            die "error while building schema class on the fly: DBIx::Class::Schema::Loader not available: $err"
+        };
+        DBIx::Class::Schema::Loader->naming('v7');
         $schemas->{$name} = DBIx::Class::Schema::Loader->connect(@conn_info);
     }
 


### PR DESCRIPTION
Hi,

Dancer::Plugin::DBIC pulls in DBIx::Class::Schema::Loader which comes with a bunch of Lingua modules, SQL::Translator, etc. All these are not needed for a production app which will never need all those development modules.

This changeset attempts to fix this by making DCSL an optional dependency. An exception is thrown at runtime if the schema_class is not defined and DCSL is not found.
