### PR TITLE
Show root cause when unable to load schema.

### DIFF
--- a/lib/Dancer/Plugin/DBIC.pm
+++ b/lib/Dancer/Plugin/DBIC.pm
@@ -39,7 +39,7 @@ sub schema {
     if ($schema_class) {
         $schema_class =~ s/-/::/g;
         eval { load $schema_class };
-        die "Could not load schema_class $schema_class" if $@;
+        die "Could not load schema_class $schema_class: $@" if $@;
         $schemas->{$name} = $schema_class->connect(@conn_info)
     } else {
         my $dbic_loader = 'DBIx::Class::Schema::Loader';


### PR DESCRIPTION
The current error message, `Could not load schema_class $schema_class`, is not very helpful for diagnosing why the schema could not be loaded.  Consider including the root cause available as `$@`.
